### PR TITLE
Make cc-unit-tests work with latest ruby-units docker image

### DIFF
--- a/ci/test-unit/run_cc_unit_tests
+++ b/ci/test-unit/run_cc_unit_tests
@@ -41,6 +41,7 @@ stop_docker() {
 pushd cloud_controller_ng > /dev/null
   start_db
 
+  export BUNDLE_GEMFILE=Gemfile
   bundle install
 
   bundle exec rake rubocop


### PR DESCRIPTION
# Summary
The latest automatically built docker image for ruby-units brought in Bundler 1.16.0, which breaks the cc-unit-tests concourse job. The error you'll get looks like:

```[!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - /Gemfile. Bundler cannot continue.```

This fix explicitly sets BUNDLE_GEMFILE to point to the correct Gemfile for cloud_controller_ng.

# Details
After upgrading from Bundler 1.15 to 1.16.0, `bundler config` is reporting that the BUNDLE_GEMFILE env var is set to /Gemfile, despite no such environment variable exisiting. To get around this, we manually override the BUNDLE_GEMFILE env var.

This fix is a quick bandaid that appears to get the units working again. The deeper cause of BUNDLE_GEMFILE appearing to be `/Gemfile` requires some more investigation. If you run cc-units in concourse, hijack into the container, then look in /usr/local/bundle (which is Bundler's app config directory), you'll see a bunch of files in the /usr/local/bundle/bin directory that all follow this pattern:

```root@5e3bc6a7-b2f5-4dac-4fd7-a3ebb5140aa6:/usr/local/bundle# cat bin/clockwork
#!/usr/bin/env ruby
# frozen_string_literal: true

#
# This file was generated by Bundler.
#
# The application 'clockwork' is installed as part of a gem, and
# this file is here to facilitate running it.
#

bundle_binstub = File.expand_path("../bundle", __FILE__)
load(bundle_binstub) if File.file?(bundle_binstub)

require "pathname"
ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../../../Gemfile",
  Pathname.new(__FILE__).realpath)

require "rubygems"
require "bundler/setup"

load Gem.bin_path("clockwork", "clockwork")
```

That `../../../../../Gemfile` filepath looks pretty suspicious, and we don't know why Bundler is generating it.

Thanks,
Jen and @deniseyu