### PR TITLE
Allow unit tests to be run in parallel in CI

### DIFF
--- a/ci/test-unit/run_cc_unit_tests
+++ b/ci/test-unit/run_cc_unit_tests
@@ -45,5 +45,9 @@ pushd cloud_controller_ng > /dev/null
   bundle install
 
   bundle exec rake rubocop
-  bundle exec rake spec:serial
+  if [ -n "${RUN_IN_PARALLEL}" ]; then
+    bundle exec rake spec:all
+  else
+    bundle exec rake spec:serial
+  fi
 popd > /dev/null

--- a/ci/test-unit/run_cc_unit_tests.yml
+++ b/ci/test-unit/run_cc_unit_tests.yml
@@ -14,3 +14,5 @@ inputs:
 run:
   path: capi-ci/ci/test-unit/run_cc_unit_tests
 
+params:
+  RUN_IN_PARALLEL: ~


### PR DESCRIPTION
This adds the ability to run the CC unit tests in parallel in CI.

**By default, nothing will change and the units will continue to run in serial.**

On the SAPI team, we've found running the units in parallel to generally be pretty successful. We have seen occaisional flakes that we didn't see when running the tests in serial, but for us, having the tests run faster is worth the occaisional need to re-run the the CI job.

To make the units run in parallel with this change, you would need to add `RUN_IN_PARALLEL: <some non-empty string>` to your build plan. If you do not specify this parameter or if you explicitly set it to `~`, the tests will run in serial.

We have generally been using the capi-ci task definitions directly in our CI so that we don't get far behind if the CAPI team makes changes to how the test suite runs. In order to run the tests in parallel, however, we needed to copy the content of these tasks into our own ci repo. This introduces the possibility for drift in the future. It'd be great to get this into the actually capi-ci files and be able to stay up-to-date with the latest that CAPI is using.

Thanks!