### PR TITLE
Make create-bosh-lite job compatible with latest bosh-deployment

### DIFF
--- a/ci/bosh-lite/create-env-vars-file.sh
+++ b/ci/bosh-lite/create-env-vars-file.sh
@@ -26,8 +26,8 @@ export BOSH_GW_HOST="$(bosh interpolate --path /external_ip "${terraform_metadat
 export BOSH_GW_PRIVATE_KEY_CONTENTS="$(bosh interpolate --path /jumpbox_ssh/private_key "${creds_file}")"
 export BOSH_LITE_DOMAIN="$(bosh interpolate --path /system_domain "${terraform_metadata_file}")"
 export CREDHUB_SERVER="$(bosh interpolate --path /external_ip "${terraform_metadata_file}"):8844"
-export CREDHUB_USERNAME="credhub-cli"
-export CREDHUB_PASSWORD="$(bosh interpolate --path /credhub_cli_password "${creds_file}")"
+export CREDHUB_CLIENT="credhub-admin"
+export CREDHUB_SECRET="$(bosh interpolate --path /credhub_admin_client_secret "${creds_file}")"
 EOD
 
 cp "${terraform_name_file}" "${output_dir}/name"


### PR DESCRIPTION
## Issue
Any bosh-lites generated with the bosh-lite pool pattern on or after January 24, 2018 will generate a env file with a blank `CREDHUB_PASSWORD`.

## Cause
[This commit](https://github.com/cloudfoundry/bosh-deployment/commit/57c212ed3004e5d91581e8f0b18416eefabc8adf) in bosh-deployment replaced the credhub uaa user with a uaa client and removed the old properties that were relied upon by the create-env-vars-file.sh script.

## Fix
This change updates create-env-vars-file.sh to look for the updated variables. We also now export `CREDHUB_CLIENT` instead of `CREDHUB_USERNAME` and `CREDHUB_SECRET` instead of `CREDHUB_PASSWORD`. This environment variables are understood by the credhub CLI itself.

## Follow-up
You should probably also update the claim-bosh-lite script in sprout-capi to replace this

`echo 'credhub login -s "\$CREDHUB_SERVER" -u "\$CREDHUB_USERNAME" -p "\$CREDHUB_PASSWORD" --skip-tls-validation'`
with
`echo 'credhub login --skip-tls-validation'`

If the environment variables `CREDHUB_SERVER`, `CREDHUB_CLIENT`, and `CREDHUB_SECRET` are set (which this PR accomplishes), `credhub login` will use those values, so nothing needs to be specified on the command line.

Thanks,
Jen and Niki (@nmaslarski)