### PR TITLE
Allow the GCP instance type to be customized

### DIFF
--- a/ci/bosh-lite/create-bosh-lite.yml
+++ b/ci/bosh-lite/create-bosh-lite.yml
@@ -19,4 +19,5 @@ run:
   path: capi-ci/ci/bosh-lite/create-bosh-lite.sh
 
 params:
-  GCP_JSON_KEY:      ""
+  GCP_JSON_KEY: ""
+  GCP_INSTANCE_TYPE: ~


### PR DESCRIPTION
If the (optional) GCP_INSTANCE_TYPE param is specified for the create-bosh-lite concourse task, the given instance type will be used when creating bosh lites.

We found that the default instance type from bosh-deployment (n1-standard-8) was overpowered for our needs, so we're using a smaller instance type to save money.

For us, n1-standard-4 is just as performant and is half the price. For more details on our experimentation to reach this conclusion, see this story: https://www.pivotaltracker.com/story/show/156622117

Note: we intentionally made this PR in a way that would not break the CAPI pipeline. A cleaner way to do this might be to add an additional concourse input to be able to provide arbitrary ops files, and then the `GCP_INSTANCE_TYPE` parameter could be removed. But that wouldn't be possible without requiring a change to the CAPI pool pipeline. If you're interested in this approach, let us know, and we can PR that instead or at a later point.

Thanks,
SAPI (@ablease and Jen)