### PR TITLE
Do not remove building bosh lite lock for a failed create bosh lite job

### DIFF
--- a/ci/pipeline-bosh-lite.yml
+++ b/ci/pipeline-bosh-lite.yml
@@ -169,25 +169,17 @@ jobs:
                 params:
                   remove: fake-placeholder-env/
             on_failure:
-              aggregate:
-              - put: building-pool
-                params:
-                  remove: fake-placeholder-env/
-              - task: delete-bosh-lite
-                file: capi-ci/ci/bosh-lite/delete-bosh-lite.yml
+              task: delete-bosh-lite
+              file: capi-ci/ci/bosh-lite/delete-bosh-lite.yml
         on_failure:
-          aggregate:
-          - put: terraform
-            params:
-              action: destroy
-              env_name_file: terraform/name
-              terraform_source: capi-ci/terraform/bosh-lite/
-              vars: *terraform-vars
-            get_params:
-              action: destroy
-          - put: building-pool
-            params:
-              remove: fake-placeholder-env/
+          put: terraform
+          params:
+            action: destroy
+            env_name_file: terraform/name
+            terraform_source: capi-ci/terraform/bosh-lite/
+            vars: *terraform-vars
+          get_params:
+            action: destroy
 
   - name: delete-bosh-lite
     plan:


### PR DESCRIPTION
When the bosh line pool was originally designed it's our understanding that if the create bosh lite fails it requires a manual (human) intervention to check what went wrong and verify all the resources were deleted. If we remove the building-bosh-lite lock on failure, a new build will be triggered. If that build isn't cleaned up properly, this could create a lot of bosh lites in your gcp project. For example we had 15 bosh lites being created. Each of them costing $200 a month, so this pipeline design can cause a lot of problems, especially if it runs over the weekend.

This change reverts to the original pipeline behaviour of leaving the lock if create-bosh-lite fails. This means as long as there is an error state, new bosh lites won't be created past the pool size. In this case a person would need to go and check what went wrong and verify all the resources were deleted and delete the lock from the building-bosh-lites-pool.

P.S. We already fixed it in our pipeline, but we're PRing this because we think it might be valuable to your team as well.
Thanks,
@nmaslarski and @jenspinney 