### PR TITLE
Cleanup variables for check-broken-pool-size

### DIFF
--- a/ci/bosh-lite/check-broken-pool-size.sh
+++ b/ci/bosh-lite/check-broken-pool-size.sh
@@ -4,8 +4,6 @@ set -eu
 
 # ENV
 : "${POOL_NAME:="broken-bosh-lites"}"
-: "${GIT_USERNAME:="CAPI CI"}"
-: "${GIT_EMAIL:="cf-capi-eng+ci@pivotal.io"}"
 
 # INPUTS
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/ci/bosh-lite/check-broken-pool-size.yml
+++ b/ci/bosh-lite/check-broken-pool-size.yml
@@ -13,3 +13,6 @@ inputs:
 
 run:
   path: capi-ci/ci/bosh-lite/check-broken-pool-size.sh
+
+params:
+  POOL_NAME: ""


### PR DESCRIPTION
- Remove `GIT_USERNAME` and `GIT_EMAIL` from check-broken-pool-size.sh
since it is not being used
- Add `POOL_NAME` as param to check-broken-pool-size.yml

[#155287687]