### PR TITLE
Fix stemcell link for cf-deployment 5.0.0

### DIFF
--- a/ci/bosh-lite/upload-cf-assets.sh
+++ b/ci/bosh-lite/upload-cf-assets.sh
@@ -11,13 +11,9 @@ env_info="${workspace_dir}/bosh-lite-env-info"
 source "${env_info}/metadata"
 
 echo "Uploading stemcell..."
-trusty_stemcell_version=$(bosh interpolate --path /stemcells/alias=default/version "${cf_deployment_repo}/cf-deployment.yml")
+stemcell_version=$(bosh interpolate --path /stemcells/alias=default/version "${cf_deployment_repo}/cf-deployment.yml")
 bosh -n upload-stemcell \
-  "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=${trusty_stemcell_version}"
-
-xenial_stemcell_version=$(bosh interpolate --path /path=~1stemcells~1alias=default~1version/value "${cf_deployment_repo}/operations/experimental/use-xenial-stemcell.yml")
-bosh -n upload-stemcell \
-  "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent?v=${xenial_stemcell_version}"
+  "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent?v=${stemcell_version}"
 
 echo "Uploading cloud-config..."
 bosh -n update-cloud-config "${cf_deployment_repo}/iaas-support/bosh-lite/cloud-config.yml"


### PR DESCRIPTION
This change fixes the bosh-lite pool so that it works with cf-deployment 5.0.0 (as of Sept 25, 2018, this is on the release-candidate branch of cf-deployment).

This change is not backwards compatible, so if the CAPI team is not using the release-candidate branch of cf-deployment, you should wait until 5.0.0 is released to merge this PR.

In cf-deployment 5.0.0, xenial is now the default stemcell, so we don't need any branching logic to figure out whether to upload trusty or xenial -- we just always use xenial.

We've tested this change with 5.0.0 of cf-deployment in our own pool pipeline, and the create-bosh-lite step succeeds.