### PR TITLE
Revert "Revert "🐞 Remove terraform's deprecation warnings""

### DIFF
--- a/terraform/bosh-lite/bosh-lite.tf
+++ b/terraform/bosh-lite/bosh-lite.tf
@@ -25,32 +25,32 @@ provider "acme" {
 }
 
 provider "google" {
-  credentials = "${var.json_key}"
-  project = "${var.project_id}"
-  region = "${var.region}"
+  credentials = var.json_key
+  project = var.project_id
+  region = var.region
 }
 
 provider "google" {
   alias = "dns"
-  credentials = "${var.dns_json_key}"
-  project = "${var.dns_project_id}"
-  region = "${var.region}"
+  credentials = var.dns_json_key
+  project = var.dns_project_id
+  region = var.region
 }
 
 resource "google_compute_network" "default" {
-  name = "${var.env_name}"
+  name = var.env_name
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name = "${var.env_name}"
-  ip_cidr_range = "${var.internal_cidr}"
-  network = "${google_compute_network.default.self_link}"
+  name = var.env_name
+  ip_cidr_range = var.internal_cidr
+  network = google_compute_network.default.self_link
 }
 
 resource "google_compute_firewall" "default" {
-  name = "${var.env_name}"
-  network = "${google_compute_network.default.name}"
+  name = var.env_name
+  network = google_compute_network.default.name
 
   allow {
     protocol = "icmp"
@@ -67,16 +67,16 @@ resource "google_compute_firewall" "default" {
 }
 
 resource "google_compute_address" "default" {
-  name = "${var.env_name}"
+  name = var.env_name
 }
 
 resource "google_dns_record_set" "default" {
-  provider = "google.dns"
+  provider = google.dns
   name = "*.${var.env_name}.${var.system_domain_suffix}."
   type = "A"
   ttl = 300
 
-  managed_zone = "${var.dns_zone_name}"
+  managed_zone = var.dns_zone_name
   rrdatas = [ "${google_compute_address.default.address}" ]
 }
 
@@ -85,12 +85,12 @@ resource "tls_private_key" "private_key" {
 }
 
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  account_key_pem = tls_private_key.private_key.private_key_pem
   email_address   = "cf-v3-acceleration@pivotal.io"
 }
 
 resource "acme_certificate" "certificate" {
-  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  account_key_pem           = acme_registration.reg.account_key_pem
   common_name = "*.${var.env_name}.${var.system_domain_suffix}"
 
   dns_challenge {


### PR DESCRIPTION
We upgraded Terraform to support this change

CF-CLI pipeline previously was pinned to an older version of Terraform.

This reverts commit 5ef6cfaf798425c894372b5651f42bcf4e7ba458.

[#169856709](https://www.pivotaltracker.com/story/show/169856709)

Co-authored-by: Brendan Smith <brsmith@pivotal.io>