### PR TITLE
Fix terraform deprecated syntax

### DIFF
--- a/terraform/bosh-lite/bosh-lite.tf
+++ b/terraform/bosh-lite/bosh-lite.tf
@@ -21,32 +21,32 @@ variable "system_domain_suffix" {}
 # RESOURCES
 
 provider "google" {
-  credentials = "${var.json_key}"
-  project = "${var.project_id}"
-  region = "${var.region}"
+  credentials = var.json_key
+  project = var.project_id
+  region = var.region
 }
 
 provider "google" {
   alias = "dns"
-  credentials = "${var.dns_json_key}"
-  project = "${var.dns_project_id}"
-  region = "${var.region}"
+  credentials = var.dns_json_key
+  project = var.dns_project_id
+  region = var.region
 }
 
 resource "google_compute_network" "default" {
-  name = "${var.env_name}"
+  name = var.env_name
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name = "${var.env_name}"
-  ip_cidr_range = "${var.internal_cidr}"
-  network = "${google_compute_network.default.self_link}"
+  name = var.env_name
+  ip_cidr_range = var.internal_cidr
+  network = google_compute_network.default.self_link
 }
 
 resource "google_compute_firewall" "default" {
-  name = "${var.env_name}"
-  network = "${google_compute_network.default.name}"
+  name = var.env_name
+  network = google_compute_network.default.name
 
   allow {
     protocol = "icmp"
@@ -59,27 +59,27 @@ resource "google_compute_firewall" "default" {
 
   source_ranges = ["0.0.0.0/0"]
 
-  target_tags = ["${var.env_name}"]
+  target_tags = [var.env_name]
 }
 
 resource "google_compute_address" "default" {
-  name = "${var.env_name}"
+  name = var.env_name
 }
 
 resource "google_dns_record_set" "default" {
-  provider = "google.dns"
+  provider = google.dns
   name = "*.${var.env_name}.${var.system_domain_suffix}."
   type = "A"
   ttl = 300
 
-  managed_zone = "${var.dns_zone_name}"
-  rrdatas = [ "${google_compute_address.default.address}" ]
+  managed_zone = var.dns_zone_name
+  rrdatas = [ google_compute_address.default.address ]
 }
 
 # OUTPUTS
 
 output "external_ip" {
-  value = "${google_compute_address.default.address}"
+  value = google_compute_address.default.address
 }
 
 output "system_domain" {
@@ -87,23 +87,23 @@ output "system_domain" {
 }
 
 output "network" {
-  value = "${google_compute_network.default.name}"
+  value = google_compute_network.default.name
 }
 
 output "subnetwork" {
-  value = "${google_compute_subnetwork.default.name}"
+  value = google_compute_subnetwork.default.name
 }
 
 output "zone" {
-  value = "${var.zone}"
+  value = var.zone
 }
 
 output "tags" {
-  value = "${google_compute_firewall.default.target_tags}"
+  value = google_compute_firewall.default.target_tags
 }
 
 output "project_id" {
-  value = "${var.project_id}"
+  value = var.project_id
 }
 
 output "internal_ip" {
@@ -115,5 +115,5 @@ output "internal_gw" {
 }
 
 output "internal_cidr" {
-  value = "${google_compute_subnetwork.default.ip_cidr_range}"
+  value = google_compute_subnetwork.default.ip_cidr_range
 }


### PR DESCRIPTION
Hello CAPI friends,

### Warnings 
We noticed these deprecation warnings in our pipeline:
```
Warning: Interpolation-only expressions are deprecated

  on bosh-lite.tf line 24, in provider "google":
  24:   credentials = "${var.json_key}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 13 more similar warnings elsewhere)


Warning: Quoted references are deprecated

  on bosh-lite.tf line 70, in resource "google_dns_record_set" "default":
  70:   provider = "google.dns"

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.
```

### Validation
We think these changes will fix this, but we are not 100% certain we did it correctly. 

With `Terraform v0.12.19`

We see:
```sh
$ terraform validate bosh-lite.tf

Error: Could not satisfy plugin requirements
...
Error: provider.google: no suitable version installed
  version requirements: "(any version)"
  versions installed: none
```
And we did not get syntax errors.

### Ask
Can you please validate our work and merge this PR? Can you please share with us a better way to validate changes to this file?

[#170835121](https://www.pivotaltracker.com/story/show/170835121)

Brendan and @a-b 
