### PR TITLE
update k8s deploy script to work with backup-metadata-generator images

### DIFF
--- a/ci/k8s/deploy-cf-for-k8s.sh
+++ b/ci/k8s/deploy-cf-for-k8s.sh
@@ -17,6 +17,7 @@ CAPI_IMAGE="cloudfoundry/cloud-controller-ng@$(get_image_digest_for_resource cap
 NGINX_IMAGE="cloudfoundry/capi-nginx@$(get_image_digest_for_resource nginx-docker-image)"
 CONTROLLERS_IMAGE="cloudfoundry/cf-api-controllers@$(get_image_digest_for_resource cf-api-controllers-docker-image)"
 REGISTRY_BUDDY_IMAGE="cloudfoundry/cf-api-package-registry-buddy@$(get_image_digest_for_resource registry-buddy-docker-image)"
+BACKUP_METADATA_GENERATOR_IMAGE="cloudfoundry/cloudfoundry/cf-api-backup-metadata-generator@$(get_image_digest_for_resource backup-metadata-docker-image)"
 
 echo "kapp version..."
 kapp version
@@ -32,6 +33,7 @@ echo "Updating ccng image to cloud_controller_ng digest: ${CAPI_IMAGE}"
 echo "Updating nginx image to capi-k8s-release digest: ${NGINX_IMAGE}"
 echo "Updating cf-api-controllers image to capi-k8s-release digest: ${CONTROLLERS_IMAGE}"
 echo "Updating registry buddy image to capi-k8s-release digest: ${REGISTRY_BUDDY_IMAGE}"
+echo "Updating backup metadata generator image to capi-k8s-release digest: ${BACKUP_METADATA_GENERATOR_IMAGE}"
 
 cat <<- EOF > "${PWD}/update-images.yml"
 ---
@@ -47,6 +49,9 @@ cat <<- EOF > "${PWD}/update-images.yml"
 - type: replace
   path: /images/registry_buddy
   value: ${REGISTRY_BUDDY_IMAGE}
+- type: replace
+  path: /images/backup_metadata
+  value: ${BACKUP_METADATA_GENERATOR_IMAGE}
 EOF
 
 pushd "capi-k8s-release"

--- a/ci/k8s/deploy-cf-for-k8s.yml
+++ b/ci/k8s/deploy-cf-for-k8s.yml
@@ -15,6 +15,7 @@ inputs:
 - name: capi-docker-image
 - name: cf-api-controllers-docker-image
 - name: registry-buddy-docker-image
+- name: backup-metadata-docker-image
 - name: nginx-docker-image
 - name: cluster-tf-state
 outputs:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -679,6 +679,13 @@ resources:
     username: ((dockerhub_user))
     password: ((dockerhub_pass))
 
+- name: backup-metadata-docker-image
+  type: registry-image
+  source:
+    repository: cloudfoundry/cf-api-backup-metadata-generator
+    username: ((dockerhub_user))
+    password: ((dockerhub_pass))
+
 jobs:
 - name: provision-samus-cluster
   plan:
@@ -1519,6 +1526,7 @@ jobs:
     - get: registry-buddy-docker-image
       trigger: true
       passed: [registry-buddy-docker-image]
+    - get: backup-metadata-docker-image
     - get: nginx-docker-image
       trigger: true
       passed: [build-nginx-docker-image]


### PR DESCRIPTION
These are currently built in the backup-metadata pipeline, but will eventually be built in the capi-k8s pipeline. I'm updating that pipeline now to use the same deployment script as `samus` and need the script to support arbitrary versions.

On Samus this will just deploy the latest version of the image which shouldn't affect any of the tests it runs.

CAKE Story: [#175080281](https://www.pivotaltracker.com/story/show/175080281)

Authored-by: Tim Downey <tdowney@vmware.com>