### PR TITLE
Don't embed version control information in the locket binary

### DIFF
--- a/ci/test-unit/run_bridge_unit_tests
+++ b/ci/test-unit/run_bridge_unit_tests
@@ -16,7 +16,7 @@ popd
 
 # building locket for TPS watcher tests
 pushd diego-release/src/code.cloudfoundry.org
-  go build -o /go/bin/locket ./locket/cmd/locket
+  go build -buildvcs=false -o /go/bin/locket ./locket/cmd/locket
 popd
 
 pushd capi-release


### PR DESCRIPTION
Otherwise Go 1.18 cannot build a binary from a submodule:
```
error obtaining VCS status: main package is in repository "<...>/diego-release/src/code.cloudfoundry.org/locket" but current directory is in repository "<...>/diego-release
```
