### PR TITLE
Increase pooled bosh-lites' disk size

### DIFF
--- a/ci/bosh-lite/use-ssd-disks.yml
+++ b/ci/bosh-lite/use-ssd-disks.yml
@@ -3,7 +3,7 @@
   value: pd-ssd
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/root_disk_size_gb?
-  value: 32
+  value: 64
 - type: replace
   path: /disk_pools/name=disks/cloud_properties?
   value:


### PR DESCRIPTION
Jammy stemcells and bosh releases are getting larger, so it's much easier to fill up the disk, which makes it impossible to upload new releases.

Example error:
```
Task 163 | 00:20:06 | Downloading remote release: Downloading remote release (00:00:13)
Task 163 | 00:20:06 | Verifying remote release: Verifying remote release (00:00:00)
Task 163 | 00:20:06 | Extracting release: Extracting release
Task 165 | 00:20:08 | Downloading remote release: Downloading remote release (00:00:11)
                    L Error: No space left on device @ io_write - /var/vcap/data/director/tmp/release-613256e1-ce27-412d-8e35-11f1883cdcf7
Task 165 | 00:20:08 | Error: No space left on device @ io_write - /var/vcap/data/director/tmp/release-613256e1-ce27-412d-8e35-11f1883cdcf7
```

I'm pretty sure this is the correct disk to increase, though I'm not sure if this change will be sufficient to increase the disk available to `/var/vcap/data`. I'm not sure how the disk is divided between the different filesystems.

```
bosh/0:~$ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0    7:0    0  7.5G  0 loop /var/vcap/data/grootfs/store/unprivileged
loop1    7:1    0  7.5G  0 loop /var/vcap/data/grootfs/store/privileged
loop2    7:2    0   10G  0 loop /var/vcap/store/warden_cpi/persistent_bind_mounts_dir/62f4e416-0797-473f-6684-2b7959fa7f3c/eefaa7f8-09a4-4192-7dae-b5f8f47ba8fb
loop3    7:3    0 97.9G  0 loop /var/vcap/store/warden_cpi/persistent_bind_mounts_dir/c8fd0ca8-48f4-4f0f-6df7-277a92ed80c1/d8f03cce-587b-484d-4b27-3d31af2efa64
loop4    7:4    0 19.6G  0 loop
loop5    7:5    0 19.6G  0 loop
sda      8:0    0   32G  0 disk
├─sda1   8:1    0  4.8G  0 part /home
│                               /
├─sda2   8:2    0 13.6G  0 part [SWAP]
└─sda3   8:3    0 13.6G  0 part /var/tmp
                                /tmp
                                /opt
                                /var/opt
                                /var/log
                                /var/vcap/data
sdb      8:16   0   64G  0 disk
└─sdb1   8:17   0   64G  0 part /var/vcap/store/warden_cpi/persistent_bind_mounts_dir/1ee3f947-1b7f-4149-5549-2d45e98b05c5
...
```