### PR TITLE
Add cve pipeline

### DIFF
--- a/ci/cve-pipeline.yml
+++ b/ci/cve-pipeline.yml
@@ -1,0 +1,24 @@
+resources:
+- name: concourse-cve-scan
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry-incubator/concourse-cve-scan.git
+    branch: main
+- name: capi-release-develop
+  type: git
+  source:
+    branch: develop
+    uri: https://github.com/cloudfoundry/capi-release.git
+jobs:
+- name: check-for-cves
+  plan:
+  - in_parallel:
+      - get: concourse-cve-scan
+      - get: capi-release-develop
+        trigger: true
+  - task: scan-with-syft-and-grype
+    input_mapping:
+      bosh-release-repo: capi-release-develop
+    file: concourse-cve-scan/tasks/scan-for-cves/scan-for-cves.yml
+    params:
+      GRYPE_FAILURE_LEVEL: critical


### PR DESCRIPTION
Some folks have been asking internally for cve pipeline.  They made https://github.com/cloudfoundry-incubator/concourse-cve-scan as an example.  This is a first pass setting critical as the threshold for failure

Currently running as separate pipeline at https://ci.capi.land/teams/main/pipelines/cve-scan.  At somepoint maybe we should make it blocking, but for now it is informational