### PR TITLE
Update baras for ginkgo v2

### DIFF
--- a/ci/baras/run-baras.sh
+++ b/ci/baras/run-baras.sh
@@ -3,9 +3,6 @@ set -xeu
 
 build_dir=${PWD}
 
-version=$(cat cf-cli/version)
-curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${version:1}&source=github-rel" | tar -zx
-mv cf7 /usr/local/bin/cf
 cf -v
 
 export CONFIG
@@ -34,11 +31,11 @@ export CF_DIAL_TIMEOUT=11
 
 export CF_PLUGIN_HOME=$HOME
 
-./bin/test -keepGoing \
-  -randomizeAllSpecs \
-  -skipPackage=helpers \
-  -slowSpecThreshold=300 \
-  --flakeAttempts="${FLAKE_ATTEMPTS}" \
+./bin/test -keep-going \
+  -randomize-all \
+  -skip-package=helpers \
+  -poll-progress-after=300s \
+  --flake-attempts="${FLAKE_ATTEMPTS}" \
   -nodes="${NODES}" \
-  -noisySkippings=false \
+  -timeout=2h \
   . stack

--- a/ci/baras/run-baras.yml
+++ b/ci/baras/run-baras.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/capi
-    tag: cf-for-k8s
+    tag: sits
 
 inputs:
   - name: capi-ci


### PR DESCRIPTION
- remove installation of v7 cli as cli is provided by sits image
- use sits image as it has ginkgo v2 installed on it (and is more maintained)
- update ginkgo flags to non-deprecated ones
- add timeout


needed for https://github.com/cloudfoundry/capi-bara-tests/pull/46