### PR TITLE
Revert "Remove tag filter for cf deployment concourse tasks as we now…

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -333,6 +333,7 @@ resources:
   type: git
   source:
     branch: main
+    tag_filter: v15.0.0
     private_key: ((private_key))
     uri: git@github.com:cloudfoundry/cf-deployment-concourse-tasks.git
 


### PR DESCRIPTION
… use latest concourse tasks"

This reverts commit ee7c75b90e1b589ccdccc122fb2c81aace81dfc0.