### PR TITLE
Update readme to say kiki uses postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [pipeline.yml](https://github.com/cloudfoundry/capi-ci/blob/main/ci/pipeline
     |                                                                      |
     |  Kiki: used for testing that db migrations are backwards compatible  |
     |          · Short-lived                                               |
-    |          · Database: MySQL                                           |
+    |          · Database: Postgres                                        |
     |          · Blobstore: WebDAV                                         |
     |                                                                      |
     |  Xena: used for testing BBR on MySQL                                 |


### PR DESCRIPTION
- was trying to understand some ci issues and discovered that kiki actually uses [postgres not mysql](https://github.com/cloudfoundry/capi-ci/blob/main/ci/pipeline.yml#L1614).  Not sure when that change happened but 🤷‍♀️