### PR TITLE
Skip Firehose v1 CATs for GCP envs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1554,6 +1554,7 @@ jobs:
               NODES: 10
               CONFIG_FILE_PATH: asha-mysql/cats_integration_config.json
               CAPTURE_LOGS: true
+              SKIP_REGEXP: "shows logs and metrics"
           - task: capi-bara-tests
             file: capi-ci/ci/baras/run-baras.yml
             input_mapping:
@@ -2007,6 +2008,7 @@ jobs:
               NODES: 10
               CONFIG_FILE_PATH: scar-psql/cats_integration_config.json
               CAPTURE_LOGS: true
+              SKIP_REGEXP: "shows logs and metrics"
           - task: capi-bara-tests
             file: capi-ci/ci/baras/run-baras.yml
             input_mapping:
@@ -2231,6 +2233,7 @@ jobs:
               NODES: 10
               CONFIG_FILE_PATH: elsa-ha/cats_integration_config.json
               CAPTURE_LOGS: true
+              SKIP_REGEXP: "shows logs and metrics"
           - task: capi-bara-tests
             file: capi-ci/ci/baras/run-baras.yml
             input_mapping:


### PR DESCRIPTION
* we want to run CATs with "skip_ssl_validation" disabled, but websocket connections on GCP are not terminated with the load balancer certificate -> skip the two tests, Firehose v1 is anyway deprecated