### PR TITLE
Enable puma in Asha

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,30 +20,35 @@ See [pipeline.yml](https://github.com/cloudfoundry/capi-ci/blob/main/ci/pipeline
     |          · Encrypted database                                        |
     |          · Clustered database                                        |
     |          · Runtime CredHub (assisted mode)                           |
+    |          . Webserver: Thin                                           |
     |          · Database: MySQL                                           |
     |          · Platform: GCP                                             |
     |          · Blobstore: GCP blobstore                                  |
     |                                                                      |
     |  Kiki: used for testing that db migrations are backwards compatible  |
     |          · Short-lived                                               |
+    |          . Webserver: Thin                                           |
     |          · Database: PostgreSQL                                      |
     |          · Platform: GCP                                             |
     |          · Blobstore: WebDAV                                         |
     |                                                                      |
-    |  Asha: used for testing CATS and CAPI-BARA tests on MySQL            |
+    |  Asha: used for testing CATS and CAPI-BARA tests on MySQL with Puma  |
     |          · Short-lived                                               |
+    |          . Webserver: Puma
     |          · Database: MySQL                                           |
     |          · Platform: GCP                                             |
     |          · Blobstore: WebDAV                                         |
     |                                                                      |
     |  Olaf: used for running CATS and CAPI-BARA tests on AWS with MySQL   |
     |          · Short-lived                                               |
+    |          . Webserver: Thin                                           |
     |          · Database: MySQL                                           |
     |          · Platform: AWS                                             |
     |          · Blobstore: S3                                             |
     |                                                                      |
     |  Scar: used for testing CATS and CAPI-BARA tests on PostgreSQL       |
     |          · Short-lived                                               |
+    |          . Webserver: Thin                                           |
     |          · Database: PostgreSQL                                      |
     |          · Platform: GCP                                             |
     |          · Blobstore: WebDAV                                         |

--- a/cf-deployment-operations/enable-puma.yml
+++ b/cf-deployment-operations/enable-puma.yml
@@ -1,0 +1,13 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/experimental?/use_puma_webserver?
+  value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/puma?/workers?
+  value: 2
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/puma?/max_threads?
+  value: 10
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/puma?/max_db_connections_per_process?
+  value: 15

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -851,6 +851,7 @@ jobs:
             cf-deployment-operations/disable-uaa-get-requests.yml
             cf-deployment-operations/seed-credhub-asg.yml
             cf-deployment-operations/seed-uaa-asg.yml
+            cf-deployment-operations/enable-puma.yml
       - task: deploy
         file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
         input_mapping:
@@ -871,6 +872,7 @@ jobs:
             base-ops-files/operations/scale-database-cluster.yml
             base-ops-files/operations/test/speed-up-dynamic-asgs.yml
             seed-uaa-asg.yml
+            enable-puma.yml
       - task: ensure-api-healthy
         file: runtime-ci/tasks/ensure-api-healthy/task.yml
         input_mapping:


### PR DESCRIPTION
See green run with this enabled https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/asha-mysql-deploy-cf/builds/291#L66cc2aad:2666

Set workers to 2 which is the default # of cpu for `small` in cf-deployment and bbl cloud config for gcp: see:
* https://github.com/cloudfoundry/cf-deployment/blob/main/cf-deployment.yml#L837
*  https://github.com/cloudfoundry/bosh-bootloader/blob/91b260941aa83c41184a383ad85e07d6b0759cfd/cloudconfig/gcp/base_ops_template.go#L78-L83