### PR TITLE
Move release notes before "ship-it" jobs

### DIFF
--- a/ci/git/generate_release_notes.sh
+++ b/ci/git/generate_release_notes.sh
@@ -4,14 +4,13 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-pushd capi-release-ci-passed > /dev/null
-  # get latest commit id of "ci-passed" branch (= new release candidate)
-  CI_PASSED_VERSION="$(git rev-parse HEAD)"
-popd > /dev/null
-
 pushd capi-release-main > /dev/null
   # get tag of last release from "main" branch
   PREVIOUS_VERSION="$(git describe --tags --abbrev=0)"
 popd > /dev/null
 
-"$SCRIPT_DIR/release_notes.rb" "$PREVIOUS_VERSION" "$CI_PASSED_VERSION"
+pushd capi-release-ci-passed > /dev/null
+  # get latest commit id of "ci-passed" branch (= new release candidate)
+  CI_PASSED_VERSION="$(git rev-parse HEAD)"
+  "$SCRIPT_DIR/release_notes.rb" "$PREVIOUS_VERSION" "$CI_PASSED_VERSION"
+popd > /dev/null

--- a/ci/git/generate_release_notes.sh
+++ b/ci/git/generate_release_notes.sh
@@ -4,10 +4,14 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-pushd capi-release > /dev/null
-  mapfile -t VERSIONS < <(git tag --sort=-v:refname | grep '^1\.' | head -n2)
-  VERSION=${VERSIONS[0]}
-  PREVIOUS_VERSION=${VERSIONS[1]}
-
-  "$SCRIPT_DIR/release_notes.rb" $PREVIOUS_VERSION $VERSION
+pushd capi-release-ci-passed > /dev/null
+  # get latest commit id of "ci-passed" branch (= new release candidate)
+  CI_PASSED_VERSION="$(git rev-parse HEAD)"
 popd > /dev/null
+
+pushd capi-release-main > /dev/null
+  # get tag of last release from "main" branch
+  PREVIOUS_VERSION="$(git describe --tags --abbrev=0)"
+popd > /dev/null
+
+"$SCRIPT_DIR/release_notes.rb" "$PREVIOUS_VERSION" "$CI_PASSED_VERSION"

--- a/ci/git/generate_release_notes.yml
+++ b/ci/git/generate_release_notes.yml
@@ -6,6 +6,7 @@ image_resource:
     repository: cloudfoundry/cf-deployment-concourse-tasks
 inputs:
   - name: capi-ci
-  - name: capi-release
+  - name: capi-release-main
+  - name: capi-release-ci-passed
 run:
   path: capi-ci/ci/git/generate_release_notes.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -40,6 +40,7 @@ groups:
       - olaf-mysql-destroy-cf
       - scar-psql-destroy-cf
       - bump-ci-passed
+      - generate-release-notes
       - rc-docs-v3
   - name: bump-dependencies
     jobs:
@@ -49,7 +50,6 @@ groups:
   - name: ship-it
     jobs:
       - ship-it
-      - generate-release-notes
       - push-github-release
       - publish-docs-v3
       - merge-capi-release-main

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1780,18 +1780,14 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-          - get: capi-release
+          - get: capi-release-main
             resource: capi-release-main
+          - get: capi-release-ci-passed
+            resource: capi-release-ci-passed
             passed:
-              - ship-it
+              - bump-ci-passed
             trigger: true
-          - get: capi-final-releases
-            passed:
-              - ship-it
           - get: capi-ci
-          - get: github-published-release
-            params:
-              globs: []
       - task: generate-release-notes
         file: capi-ci/ci/git/generate_release_notes.yml
   - name: push-github-release


### PR DESCRIPTION
Move generate-release-notes job after "bump-ci-passed" job and print the diff between the last "ci-passed" revision and the last released revision from "main". So we always see the diff between the last validated revision and the last release. This helps to decide when to cut a new release (similar to the cf-deployment release notes process).

Not yet tested!