### PR TITLE
Downgrade pool-resource to v1.3.2

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -93,6 +93,11 @@ resource_types:
     type: registry-image
     source:
       repository: frodenas/gcs-resource
+  - name: pool
+    type: registry-image
+    source:
+      repository: concourse/pool-resource
+      tag: 1.3.2
 resources:
   - name: nightly
     type: time


### PR DESCRIPTION
* this version is hopefully not affected by the timeout issue: https://github.com/concourse/pool-resource/issues/73