### PR TITLE
Revert "Fix untar command"

### DIFF
--- a/ci/migrations/apply_latest_migrations.sh
+++ b/ci/migrations/apply_latest_migrations.sh
@@ -32,7 +32,7 @@ upload_capi_release_tarball() {
 unpack_capi_release_tarball() {
   echo "Unpacking capi-release tarball..."
   bosh ssh -d "${BOSH_DEPLOYMENT_NAME}" "${BOSH_API_INSTANCE}" \
-    "cd /tmp; tar -xzf ${CAPI_REL_TGZ} ./packages/cloud_controller_ng.tgz; cd packages; tar -xzf cloud_controller_ng.tgz"
+    "cd /tmp; tar -xzf ${CAPI_REL_TGZ} packages/cloud_controller_ng.tgz; cd packages; tar -xzf cloud_controller_ng.tgz"
 }
 
 copy_db_migrations() {


### PR DESCRIPTION
This reverts commit 5bcab7b48019c6d6e4fe21caff24ff8253afbb33.

The untar command for the capi.tgz currently fails because `./packages/cloud_controller_ng.tgz` cannot be found:
https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/kiki-mig-deploy-cf/builds/290

A previous run failed because `packages/cloud_controller_ng.tgz` could not be found:
https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/kiki-mig-deploy-cf/builds/281

Don't know why... Different bosh CLI version?