### PR TITLE
Serialize the "postgres" and "mysql" unit tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -514,21 +514,20 @@ jobs:
           - get: cloud_controller_ng
             trigger: true
           - get: capi-ci
-      - in_parallel:
-          - task: run-cc-unit-tests-mysql
-            attempts: 3
-            file: capi-ci/ci/test-unit/run_cc_unit_tests.yml
-            privileged: true
-            params:
-              DB: mysql
-              RUN_IN_PARALLEL: true
-          - task: run-cc-unit-tests-postgres
-            attempts: 3
-            file: capi-ci/ci/test-unit/run_cc_unit_tests.yml
-            privileged: true
-            params:
-              DB: postgres
-              RUN_IN_PARALLEL: true
+      - task: run-cc-unit-tests-mysql
+        attempts: 3
+        file: capi-ci/ci/test-unit/run_cc_unit_tests.yml
+        privileged: true
+        params:
+          DB: mysql
+          RUN_IN_PARALLEL: true
+      - task: run-cc-unit-tests-postgres
+        attempts: 3
+        file: capi-ci/ci/test-unit/run_cc_unit_tests.yml
+        privileged: true
+        params:
+          DB: postgres
+          RUN_IN_PARALLEL: true
   - name: bridge-unit-tests
     plan:
       - in_parallel:


### PR DESCRIPTION
* The unit tests require a substantial amount of resources. If they run in parallel, workers may crash and we get orange jobs. This affects other jobs in the pipeline which have to be manually restarted.