### PR TITLE
Use e2 instead of n1 GCP VMs for BOSH Lites

### DIFF
--- a/ci/bosh-lite/create-bosh-lite.sh
+++ b/ci/bosh-lite/create-bosh-lite.sh
@@ -45,7 +45,7 @@ pushd "${state_dir}" > /dev/null
     -o "${deployment_repo}/gcp/cpi.yml" \
     -o "${deployment_repo}/bosh-lite.yml" \
     -o "${deployment_repo}/bosh-lite-runc.yml" \
-    -o "${deployment_repo}/gcp/bosh-lite-vm-type.yml" \
+    -o "${script_dir}/use-e2-standard-8.yml" \
     -o "${deployment_repo}/jumpbox-user.yml" \
     -o "${deployment_repo}/external-ip-not-recommended.yml" \
     -o "${deployment_repo}/uaa.yml" \

--- a/ci/bosh-lite/use-e2-standard-8.yml
+++ b/ci/bosh-lite/use-e2-standard-8.yml
@@ -1,0 +1,5 @@
+---
+# Configure sizes for bosh-lite on gcp
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/machine_type
+  value: e2-standard-8


### PR DESCRIPTION
- These VMs are more cost effective and should save $75-100 a month
- If these work well for us I am planning on PR-ing bosh-deployment https://github.com/cloudfoundry/bosh-deployment/blob/master/gcp/bosh-lite-vm-type.yml

![Screenshot 2025-04-15 at 9 55 12 AM](https://github.com/user-attachments/assets/35e44b8b-015b-41bb-9d3c-1b29910d358f)
