### PR TITLE
Reduce unclaimed env count from 4 -> 1

### DIFF
--- a/ci/pipeline-bosh-lite.yml
+++ b/ci/pipeline-bosh-lite.yml
@@ -245,7 +245,7 @@ jobs:
         input_mapping:
           env-pool: pool-repo
         params:
-          MIN_UNCLAIMED_COUNT: 4
+          MIN_UNCLAIMED_COUNT: 1
           GIT_USERNAME: ((ari-wg-gitbot-username))
           GIT_EMAIL: ((ari-wg-gitbot-email))
       - put: pool-repo


### PR DESCRIPTION
- Reduce costs by having fewer intentionally-idle environments
- With current pool usage, there is less demand for environments than there has been historically
- Users may need to wait for environments to provision during periods of unusually high demand
- Failure case: If a single environments get stuck in "building", it will now clog the pool