### PR TITLE
Remove non-alphanumeric characters from env names

### DIFF
--- a/ci/bosh-lite/name-bosh-lite.sh
+++ b/ci/bosh-lite/name-bosh-lite.sh
@@ -3,10 +3,14 @@
 set -eu
 
 # INPUTS
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-workspace_dir="$( cd "${script_dir}/../../.." && pwd )"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_dir="$(cd "${script_dir}/../../.." && pwd)"
 
 # OUTPUTS
 env_name="${workspace_dir}/env-name/env-name"
 
-grep '^.\{1,10\}$' /usr/share/dict/words | shuf -n1 | tr '[:upper:]' '[:lower:]' | tee "$env_name"
+grep '^.\{1,10\}$' /usr/share/dict/words |
+  shuf -n1 |
+  tr -dc '[:alnum:]\n\r' |
+  tr '[:upper:]' '[:lower:]' |
+  tee "$env_name"


### PR DESCRIPTION
- Creating bosh lites was frequently failing because the dictionary includes works with special characters (e.g. "[bunting's](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/bosh-lites/jobs/create-bosh-lite/builds/171)")