### PR TITLE
Revert "Use e2 instead of n1 GCP VMs for BOSH Lites (#127)"

### DIFF
--- a/ci/bosh-lite/create-bosh-lite.sh
+++ b/ci/bosh-lite/create-bosh-lite.sh
@@ -45,7 +45,7 @@ pushd "${state_dir}" > /dev/null
     -o "${deployment_repo}/gcp/cpi.yml" \
     -o "${deployment_repo}/bosh-lite.yml" \
     -o "${deployment_repo}/bosh-lite-runc.yml" \
-    -o "${script_dir}/use-e2-standard-8.yml" \
+    -o "${deployment_repo}/gcp/bosh-lite-vm-type.yml" \
     -o "${deployment_repo}/jumpbox-user.yml" \
     -o "${deployment_repo}/external-ip-not-recommended.yml" \
     -o "${deployment_repo}/uaa.yml" \

--- a/ci/bosh-lite/use-e2-standard-8.yml
+++ b/ci/bosh-lite/use-e2-standard-8.yml
@@ -1,5 +1,0 @@
----
-# Configure sizes for bosh-lite on gcp
-- type: replace
-  path: /resource_pools/name=vms/cloud_properties/machine_type
-  value: e2-standard-8


### PR DESCRIPTION
e2 machine types are now the default in bosh-deployment https://github.com/cloudfoundry/bosh-deployment/pull/482

This reverts commit ee48dcbec34fb5fd718f817960e8aaea0dc4da92.