### PR TITLE
Tag/label bosh lite VMs

### DIFF
--- a/ci/bosh-lite/create-bosh-lite.sh
+++ b/ci/bosh-lite/create-bosh-lite.sh
@@ -14,6 +14,7 @@ terraform_dir="${workspace_dir}/terraform"
 # OUTPUTS
 state_dir="${workspace_dir}/director-state"
 
+env_name="$(cat "${workspace_dir}/terraform/name")"
 additional_args=''
 if [ -n "${GCP_INSTANCE_TYPE}" ]; then
   cat > ${script_dir}/custom-vm-size.yml << EOD
@@ -53,8 +54,10 @@ pushd "${state_dir}" > /dev/null
     -o "${deployment_repo}/credhub.yml" \
     -o "${script_dir}/use-external-ip-credhub.yml" ${additional_args} \
     -o "${script_dir}/use-ssd-disks.yml" \
+    -o "${script_dir}/tag-bosh-lite-env.yml" \
     -v director_name="bosh-lite" \
     -v gcp_credentials_json="'${GCP_JSON_KEY}'" \
+    -v env_name="${env_name}" \
     -l "${terraform_dir}/metadata" \
     > ./director.yml
 

--- a/ci/bosh-lite/tag-bosh-lite-env.yml
+++ b/ci/bosh-lite/tag-bosh-lite-env.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /tags?
+  value:
+    environment: ((env_name))
+    component: bosh-lite-pool


### PR DESCRIPTION
- To make it clear in the IaaS UIs which VMs are part of the pool, and which environment each VM is