### PR TITLE
Fail bump-nginx-blob job when pinned stable line is EOL

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2136,6 +2136,8 @@ jobs:
             resource: capi-release-develop
             params:
               submodules: none
+      - task: check-nginx-stable-line
+        file: capi-ci/ci/update-packages/check_nginx_stable_line.yml
       - task: update-nginx-blob
         file: capi-ci/ci/update-packages/update_nginx_blob.yml
         params:

--- a/ci/update-packages/check_nginx_stable_line.sh
+++ b/ci/update-packages/check_nginx_stable_line.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+pipeline_file="capi-ci/ci/pipeline.yml"
+endoflife_url="https://endoflife.date/api/nginx.json"
+
+if [[ ! -f "${pipeline_file}" ]]; then
+  echo "Error: ${pipeline_file} not found."
+  exit 1
+fi
+
+pinned_branch=$(yq '.resources[] | select(.name == "nginx-release") | .source.branch' "${pipeline_file}") || { echo "Error: yq failed to read ${pipeline_file}."; exit 1; }
+
+if [[ -z "${pinned_branch}" || "${pinned_branch}" == "null" ]]; then
+  echo "Error: nginx-release resource not found in ${pipeline_file}, or it has no source.branch."
+  exit 1
+fi
+
+if [[ "${pinned_branch}" != stable-* ]]; then
+  echo "Error: nginx-release branch is '${pinned_branch}', expected 'stable-X.Y'."
+  exit 1
+fi
+
+pinned_cycle="${pinned_branch#stable-}"
+echo "Pinned nginx stable line: stable-${pinned_cycle}"
+
+today=$(date -u +%F)
+
+endoflife_json=$(curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${endoflife_url}") || { echo "Error: failed to fetch ${endoflife_url} after retries."; exit 1; }
+
+pinned_entry=$(echo "${endoflife_json}" | jq --arg cycle "${pinned_cycle}" '.[] | select(.cycle == $cycle)') || { echo "Error: jq failed to parse response from ${endoflife_url}."; exit 1; }
+
+if [[ -z "${pinned_entry}" ]]; then
+  echo "Error: pinned cycle '${pinned_cycle}' not found in ${endoflife_url} response."
+  exit 1
+fi
+
+pinned_eol=$(echo "${pinned_entry}" | jq -r '.eol')
+
+if [[ "${pinned_eol}" == "false" ]] || [[ "${pinned_eol}" > "${today}" ]]; then
+  echo "Pinned nginx stable line is still supported (eol: ${pinned_eol})."
+  exit 0
+fi
+
+supported_cycles=$(echo "${endoflife_json}" | jq -r --arg today "${today}" '.[] | select(.eol == false or .eol > $today) | .cycle') || { echo "Error: jq failed to filter supported cycles."; exit 1; }
+
+if [[ -z "${supported_cycles}" ]]; then
+  echo "Error: no currently-supported nginx cycles found in ${endoflife_url} response."
+  exit 1
+fi
+
+echo
+echo "ERROR: pinned nginx stable line is end-of-life."
+echo "  Pinned:    stable-${pinned_cycle}"
+echo "  EOL date:  ${pinned_eol}"
+echo "  Today:     ${today}"
+echo
+echo "Currently-supported nginx cycles (per ${endoflife_url}):"
+echo "${supported_cycles}" | sed 's/^/  - /'
+echo
+echo "Pick a stable cycle (even minor version, e.g. 1.30) and update the nginx-release resource in capi-ci/ci/pipeline.yml:"
+echo "    branch: stable-<cycle>"
+echo "    tag_regex: release-<cycle>\\..*"
+exit 1

--- a/ci/update-packages/check_nginx_stable_line.yml
+++ b/ci/update-packages/check_nginx_stable_line.yml
@@ -1,0 +1,10 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/cf-deployment-concourse-tasks
+inputs:
+  - name: capi-ci
+run:
+  path: capi-ci/ci/update-packages/check_nginx_stable_line.sh


### PR DESCRIPTION
The bump-nginx-blob job is pinned to a single nginx stable line (e.g. stable-1.28) and only picks up patch releases within it. When upstream cuts a new stable line, nothing in the pipeline notices.

Add a check-nginx-stable-line task that runs before update-nginx-blob. It reads the pinned cycle from pipeline.yml, queries https://endoflife.date/api/nginx.json, and fails the job if the pinned cycle is past EOL. The error lists the currently-supported cycles so the maintainer can pick one and update the resource pin.

Fails closed on any error (network, schema, parse) with curl retries to absorb transient blips.