### PR TITLE
Move scar to region `centralus`

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2648,7 +2648,7 @@ jobs:
           BBL_AZURE_CLIENT_SECRET: ((capi-bbl-scar-azure-client-secret))
           BBL_AZURE_SUBSCRIPTION_ID: ((capi-bbl-scar-azure-subscription-id))
           BBL_AZURE_TENANT_ID: ((capi-bbl-scar-azure-tenant-id))
-          BBL_AZURE_REGION: eastus2
+          BBL_AZURE_REGION: centralus
           BBL_LB_CERT: ../scar-psql.pfx
           BBL_LB_KEY: ../pfx_password.txt
           LB_DOMAIN: *scar-psql-domain


### PR DESCRIPTION
We were not able to get sufficient quota in region `eastus2`. Thus moving scar to region `centralus` which should have similar costs but has sufficient quotas.