### PR TITLE
Automate jemalloc blob updates

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -283,6 +283,15 @@ resources:
       owner: cloudfoundry
       repository: storage-cli
       access_token: ((ari-wg-gitbot-token))
+  - name: jemalloc-release
+    type: github-release
+    icon: github
+    source:
+      owner: jemalloc
+      repository: jemalloc
+      globs:
+      - "jemalloc-*.tar.bz2"
+      access_token: ((ari-wg-gitbot-token))
   - name: capi-ci
     type: git
     icon: git
@@ -2185,6 +2194,28 @@ jobs:
               submodules: none
       - task: update-storagecli-blob
         file: capi-ci/ci/update-packages/update_storagecli_blob.yml
+        params:
+          PRIVATE_YAML: ((capi_release_private_yaml))
+      - put: capi-release-develop
+        params:
+          repository: updated-capi-release
+          rebase: true
+  - name: bump-jemalloc-blob
+    serial: true
+    plan:
+      - in_parallel:
+          - get: jemalloc-release
+            trigger: true
+            params:
+              globs:
+                - jemalloc-*.tar.bz2
+          - get: capi-ci
+          - get: capi-release
+            resource: capi-release-develop
+            params:
+              submodules: none
+      - task: update-jemalloc-blob
+        file: capi-ci/ci/update-packages/update_jemalloc_blob.yml
         params:
           PRIVATE_YAML: ((capi_release_private_yaml))
       - put: capi-release-develop

--- a/ci/update-packages/update_jemalloc_blob.sh
+++ b/ci/update-packages/update_jemalloc_blob.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+# #!/bin/bash
 
-set -eu -o pipefail
+# set -eu -o pipefail
 
-if [[ -z "${PRIVATE_YAML}" ]]; then
-  echo "Error: PRIVATE_YAML is not set."
-  exit 1
-fi
+# if [[ -z "${PRIVATE_YAML}" ]]; then
+#   echo "Error: PRIVATE_YAML is not set."
+#   exit 1
+# fi
 
-echo "${PRIVATE_YAML}" > "${PWD}/capi-release/config/private.yml"
+# echo "${PRIVATE_YAML}" > "${PWD}/capi-release/config/private.yml"
 
 pushd capi-release > /dev/null
-  current_jemalloc_blob_fullname=$(grep -m 1 "jemalloc" config/blobs.yml | awk -F':' '{print $1}') || { echo "Error: grep command failed."; exit 1; }
-  current_jemalloc_version=$(echo "${current_jemalloc_blob_fullname}" | awk -F'/' '{print $2}' | awk -F'jemalloc-' '{print $2}' | awk -F'.tar.bz2' '{print $1}') || { echo "Error: awk command failed."; exit 1; }
+  current_jemalloc_blob_fullname=$(yq '. | keys | map(select(test("jemalloc"))) | .[0]' config/blobs.yml) || { echo "Error: yq failed to read blobs.yml."; exit 1; }
+  current_jemalloc_version=$(yq '. | keys | map(select(test("jemalloc"))) | .[0] | capture("jemalloc-(?P<version>[0-9.]+)\.tar\.bz2") | .version' config/blobs.yml) || { echo "Error: yq failed to parse jemalloc version."; exit 1; }
 
   if [ -z "$current_jemalloc_blob_fullname" ] || [ -z "$current_jemalloc_version" ]; then
     echo "Error: Either no jemalloc entry found in blobs.yml or could not parse the version."
@@ -21,34 +21,34 @@ pushd capi-release > /dev/null
   echo "Current jemalloc version is '${current_jemalloc_version}'"
 popd > /dev/null
 
-pushd jemalloc-release > /dev/null
-  new_jemalloc_version=$(cat version) || { echo "Error: cat command for version failed."; exit 1; }
-  new_jemalloc_tarball="${PWD}/jemalloc-${new_jemalloc_version}.tar.bz2"
-  new_jemalloc_url=$(cat url) || { echo "Error: cat command for url failed."; exit 1; }
-  echo "New jemalloc version is '${new_jemalloc_version}'"
-popd > /dev/null
+# pushd jemalloc-release > /dev/null
+#   new_jemalloc_version=$(cat version) || { echo "Error: cat command for version failed."; exit 1; }
+#   new_jemalloc_tarball="${PWD}/jemalloc-${new_jemalloc_version}.tar.bz2"
+#   new_jemalloc_url=$(cat url) || { echo "Error: cat command for url failed."; exit 1; }
+#   echo "New jemalloc version is '${new_jemalloc_version}'"
+# popd > /dev/null
 
-if [[ "$current_jemalloc_version" == "$new_jemalloc_version" ]]; then
-  echo "jemalloc is already at version '${current_jemalloc_version}', nothing to update."
-else
-  pushd capi-release > /dev/null
-    bosh remove-blob -n "${current_jemalloc_blob_fullname}"
-    bosh add-blob -n "$new_jemalloc_tarball" jemalloc/jemalloc-"${new_jemalloc_version}".tar.bz2
+# if [[ "$current_jemalloc_version" == "$new_jemalloc_version" ]]; then
+#   echo "jemalloc is already at version '${current_jemalloc_version}', nothing to update."
+# else
+#   pushd capi-release > /dev/null
+#     bosh remove-blob -n "${current_jemalloc_blob_fullname}"
+#     bosh add-blob -n "$new_jemalloc_tarball" jemalloc/jemalloc-"${new_jemalloc_version}".tar.bz2
 
-    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/packaging || { echo "Error: sed command for 'packaging' failed."; exit 1; }
-    sed -i "s/$current_jemalloc_version/$new_jemalloc_version/g" packages/jemalloc/README.md || { echo "Error: sed command for 'README' failed."; exit 1; }
-    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/spec || { echo "Error: sed command for 'spec' failed."; exit 1; }
+#     sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/packaging || { echo "Error: sed command for 'packaging' failed."; exit 1; }
+#     sed -i "s/$current_jemalloc_version/$new_jemalloc_version/g" packages/jemalloc/README.md || { echo "Error: sed command for 'README' failed."; exit 1; }
+#     sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/spec || { echo "Error: sed command for 'spec' failed."; exit 1; }
 
-    bosh upload-blobs -n
+#     bosh upload-blobs -n
 
-    git --no-pager diff packages .final_builds config
+#     git --no-pager diff packages .final_builds config
 
-    git config user.name "ari-wg-gitbot"
-    git config user.email "app-runtime-interfaces@cloudfoundry.org"
+#     git config user.name "ari-wg-gitbot"
+#     git config user.email "app-runtime-interfaces@cloudfoundry.org"
 
-    git add -A packages .final_builds config
-    git commit -m "Bump jemalloc to $new_jemalloc_version" -m "Changes: $new_jemalloc_url"  || { echo "Error: git commit failed."; exit 1; }
-  popd > /dev/null
-fi
+#     git add -A packages .final_builds config
+#     git commit -m "Bump jemalloc to $new_jemalloc_version" -m "Changes: $new_jemalloc_url"  || { echo "Error: git commit failed."; exit 1; }
+#   popd > /dev/null
+# fi
 
-cp -r capi-release/. updated-capi-release
+# cp -r capi-release/. updated-capi-release

--- a/ci/update-packages/update_jemalloc_blob.sh
+++ b/ci/update-packages/update_jemalloc_blob.sh
@@ -1,13 +1,13 @@
-# #!/bin/bash
+#!/bin/bash
 
-# set -eu -o pipefail
+set -eu -o pipefail
 
-# if [[ -z "${PRIVATE_YAML}" ]]; then
-#   echo "Error: PRIVATE_YAML is not set."
-#   exit 1
-# fi
+if [[ -z "${PRIVATE_YAML}" ]]; then
+  echo "Error: PRIVATE_YAML is not set."
+  exit 1
+fi
 
-# echo "${PRIVATE_YAML}" > "${PWD}/capi-release/config/private.yml"
+echo "${PRIVATE_YAML}" > "${PWD}/capi-release/config/private.yml"
 
 pushd capi-release > /dev/null
   current_jemalloc_blob_fullname=$(yq '. | keys | map(select(test("jemalloc"))) | .[0]' config/blobs.yml) || { echo "Error: yq failed to read blobs.yml."; exit 1; }
@@ -21,34 +21,34 @@ pushd capi-release > /dev/null
   echo "Current jemalloc version is '${current_jemalloc_version}'"
 popd > /dev/null
 
-# pushd jemalloc-release > /dev/null
-#   new_jemalloc_version=$(cat version) || { echo "Error: cat command for version failed."; exit 1; }
-#   new_jemalloc_tarball="${PWD}/jemalloc-${new_jemalloc_version}.tar.bz2"
-#   new_jemalloc_url=$(cat url) || { echo "Error: cat command for url failed."; exit 1; }
-#   echo "New jemalloc version is '${new_jemalloc_version}'"
-# popd > /dev/null
+pushd jemalloc-release > /dev/null
+  new_jemalloc_version=$(cat version) || { echo "Error: cat command for version failed."; exit 1; }
+  new_jemalloc_tarball="${PWD}/jemalloc-${new_jemalloc_version}.tar.bz2"
+  new_jemalloc_url=$(cat url) || { echo "Error: cat command for url failed."; exit 1; }
+  echo "New jemalloc version is '${new_jemalloc_version}'"
+popd > /dev/null
 
-# if [[ "$current_jemalloc_version" == "$new_jemalloc_version" ]]; then
-#   echo "jemalloc is already at version '${current_jemalloc_version}', nothing to update."
-# else
-#   pushd capi-release > /dev/null
-#     bosh remove-blob -n "${current_jemalloc_blob_fullname}"
-#     bosh add-blob -n "$new_jemalloc_tarball" jemalloc/jemalloc-"${new_jemalloc_version}".tar.bz2
+if [[ "$current_jemalloc_version" == "$new_jemalloc_version" ]]; then
+  echo "jemalloc is already at version '${current_jemalloc_version}', nothing to update."
+else
+  pushd capi-release > /dev/null
+    bosh remove-blob -n "${current_jemalloc_blob_fullname}"
+    bosh add-blob -n "$new_jemalloc_tarball" jemalloc/jemalloc-"${new_jemalloc_version}".tar.bz2
 
-#     sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/packaging || { echo "Error: sed command for 'packaging' failed."; exit 1; }
-#     sed -i "s/$current_jemalloc_version/$new_jemalloc_version/g" packages/jemalloc/README.md || { echo "Error: sed command for 'README' failed."; exit 1; }
-#     sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/spec || { echo "Error: sed command for 'spec' failed."; exit 1; }
+    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/packaging || { echo "Error: sed command for 'packaging' failed."; exit 1; }
+    sed -i "s/$current_jemalloc_version/$new_jemalloc_version/g" packages/jemalloc/README.md || { echo "Error: sed command for 'README' failed."; exit 1; }
+    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/spec || { echo "Error: sed command for 'spec' failed."; exit 1; }
 
-#     bosh upload-blobs -n
+    bosh upload-blobs -n
 
-#     git --no-pager diff packages .final_builds config
+    git --no-pager diff packages .final_builds config
 
-#     git config user.name "ari-wg-gitbot"
-#     git config user.email "app-runtime-interfaces@cloudfoundry.org"
+    git config user.name "ari-wg-gitbot"
+    git config user.email "app-runtime-interfaces@cloudfoundry.org"
 
-#     git add -A packages .final_builds config
-#     git commit -m "Bump jemalloc to $new_jemalloc_version" -m "Changes: $new_jemalloc_url"  || { echo "Error: git commit failed."; exit 1; }
-#   popd > /dev/null
-# fi
+    git add -A packages .final_builds config
+    git commit -m "Bump jemalloc to $new_jemalloc_version" -m "Changes: $new_jemalloc_url"  || { echo "Error: git commit failed."; exit 1; }
+  popd > /dev/null
+fi
 
-# cp -r capi-release/. updated-capi-release
+cp -r capi-release/. updated-capi-release

--- a/ci/update-packages/update_jemalloc_blob.sh
+++ b/ci/update-packages/update_jemalloc_blob.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+if [[ -z "${PRIVATE_YAML}" ]]; then
+  echo "Error: PRIVATE_YAML is not set."
+  exit 1
+fi
+
+echo "${PRIVATE_YAML}" > "${PWD}/capi-release/config/private.yml"
+
+pushd capi-release > /dev/null
+  current_jemalloc_blob_fullname=$(grep -m 1 "jemalloc" config/blobs.yml | awk -F':' '{print $1}') || { echo "Error: grep command failed."; exit 1; }
+  current_jemalloc_version=$(echo "${current_jemalloc_blob_fullname}" | awk -F'/' '{print $2}' | awk -F'jemalloc-' '{print $2}' | awk -F'.tar.bz2' '{print $1}') || { echo "Error: awk command failed."; exit 1; }
+
+  if [ -z "$current_jemalloc_blob_fullname" ] || [ -z "$current_jemalloc_version" ]; then
+    echo "Error: Either no jemalloc entry found in blobs.yml or could not parse the version."
+    exit 1
+  fi
+
+  echo "Current jemalloc version is '${current_jemalloc_version}'"
+popd > /dev/null
+
+pushd jemalloc-release > /dev/null
+  new_jemalloc_version=$(cat version) || { echo "Error: cat command for version failed."; exit 1; }
+  new_jemalloc_tarball="${PWD}/jemalloc-${new_jemalloc_version}.tar.bz2"
+  new_jemalloc_url=$(cat url) || { echo "Error: cat command for url failed."; exit 1; }
+  echo "New jemalloc version is '${new_jemalloc_version}'"
+popd > /dev/null
+
+if [[ "$current_jemalloc_version" == "$new_jemalloc_version" ]]; then
+  echo "jemalloc is already at version '${current_jemalloc_version}', nothing to update."
+else
+  pushd capi-release > /dev/null
+    bosh remove-blob -n "${current_jemalloc_blob_fullname}"
+    bosh add-blob -n "$new_jemalloc_tarball" jemalloc/jemalloc-"${new_jemalloc_version}".tar.bz2
+
+    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/packaging || { echo "Error: sed command for 'packaging' failed."; exit 1; }
+    sed -i "s/$current_jemalloc_version/$new_jemalloc_version/g" packages/jemalloc/README.md || { echo "Error: sed command for 'README' failed."; exit 1; }
+    sed -i "0,/$current_jemalloc_version/s//$new_jemalloc_version/" packages/jemalloc/spec || { echo "Error: sed command for 'spec' failed."; exit 1; }
+
+    bosh upload-blobs -n
+
+    git --no-pager diff packages .final_builds config
+
+    git config user.name "ari-wg-gitbot"
+    git config user.email "app-runtime-interfaces@cloudfoundry.org"
+
+    git add -A packages .final_builds config
+    git commit -m "Bump jemalloc to $new_jemalloc_version" -m "Changes: $new_jemalloc_url"  || { echo "Error: git commit failed."; exit 1; }
+  popd > /dev/null
+fi
+
+cp -r capi-release/. updated-capi-release

--- a/ci/update-packages/update_jemalloc_blob.yml
+++ b/ci/update-packages/update_jemalloc_blob.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/cf-deployment-concourse-tasks
+inputs:
+  - name: capi-ci
+  - name: capi-release
+  - name: jemalloc-release
+outputs:
+  - name: updated-capi-release
+run:
+  path: capi-ci/ci/update-packages/update_jemalloc_blob.sh
+params:
+  PRIVATE_YAML: ~


### PR DESCRIPTION
Adds a Concourse job to automatically bump the jemalloc blob in capi-release when a new version is released on GitHub
Changes:
- New jemalloc-release GitHub release resource (fetches .tar.bz2 source tarball)
- New bump-jemalloc-blob pipeline job that triggers on new releases
- New update_jemalloc_blob.sh script that replaces the blob, updates package refs, and commits