### PR TITLE
Align release notes scripts

### DIFF
--- a/ci/git/Gemfile.lock
+++ b/ci/git/Gemfile.lock
@@ -48,4 +48,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/ci/git/generate_github_release.sh
+++ b/ci/git/generate_github_release.sh
@@ -6,17 +6,8 @@ FINAL_RELEASE_DIR=capi-final-releases/
 PREVIOUS_RELEASE_TAG=$(cat github-published-release/tag)
 pushd capi-release > /dev/null
   SHA_CAPI=$(git rev-parse HEAD)
-  echo $SHA_CAPI > ../$FINAL_RELEASE_DIR/commitish
-  PREVIOUS_SHA_CC=$(git rev-parse $PREVIOUS_RELEASE_TAG:./src/cloud_controller_ng)
-  pushd src/cloud_controller_ng > /dev/null
-    SHA_CC=$(git rev-parse HEAD)
-    MIGRATIONS=($(git diff --diff-filter=A --name-only $PREVIOUS_SHA_CC db/migrations))
-    pushd config > /dev/null
-      VERSION_V2=$(cat version_v2)
-      VERSION_V3=$(cat version)
-      VERSION_BROKER_API=$(cat osbapi_version)
-    popd > /dev/null
-  popd > /dev/null
+  echo "$SHA_CAPI" > "../$FINAL_RELEASE_DIR/commitish"
+  ruby ../release_notes.rb "$PREVIOUS_RELEASE_TAG" HEAD src/cloud_controller_ng > "../$FINAL_RELEASE_DIR/body"
 popd > /dev/null
 
 ALL_CAPI_REL_TGZS=( "$FINAL_RELEASE_DIR"/capi-*.tgz )
@@ -39,34 +30,5 @@ fi
 
 echo "CAPI ${VERSION_CAPI}" > $FINAL_RELEASE_DIR/name
 echo "${VERSION_CAPI}" > $FINAL_RELEASE_DIR/version
-
-MIGRATIONS_FORMATTED=()
-if [[ ${#MIGRATIONS[@]} -eq '0' ]]; then
-  MIGRATIONS_FORMATTED+=("None")
-else
-  for i in "${MIGRATIONS[@]}"
-  do
-    MIGRATIONS_FORMATTED+=("- [$(basename $i)](https://github.com/cloudfoundry/cloud_controller_ng/blob/$SHA_CC/$i)")
-  done
-fi
-
-# body == release notes
-cat <<EOF > $FINAL_RELEASE_DIR/body
-**Highlights**
-
-**CC API Version: $VERSION_V2 and [$VERSION_V3](http://v3-apidocs.cloudfoundry.org/version/$VERSION_V3/)**
-
-**Service Broker API Version: [$VERSION_BROKER_API](https://github.com/openservicebrokerapi/servicebroker/blob/v$VERSION_BROKER_API/spec.md)**
-
-### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/$SHA_CAPI)
-
-### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/$SHA_CC)
-
-#### Cloud Controller Database Migrations
-
-$( IFS=$'\n'; echo "${MIGRATIONS_FORMATTED[*]}" )
-
-#### Pull Requests and Issues
-EOF
 
 cp -r capi-final-releases/. generated-release

--- a/ci/git/generate_release_notes.sh
+++ b/ci/git/generate_release_notes.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# To test the release notes generations locally, run in this folder:
+# git clone --recursive --branch=main https://github.com/cloudfoundry/capi-release.git capi-release-main
+# git clone --recursive --branch=develop https://github.com/cloudfoundry/capi-release.git capi-release-ci-passed
+# ./generate_release_notes.sh
+
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/ci/git/release_notes.rb
+++ b/ci/git/release_notes.rb
@@ -4,7 +4,6 @@
 require 'cgi/util'
 require 'net/http'
 require 'json'
-require 'set'
 
 module ReleaseNotes
   def self.execute_git_log_command(previous_version, version)
@@ -162,6 +161,8 @@ module ReleaseNotes
   def self.print_highlights(ccng_path)
     versions = read_cc_versions(ccng_path)
 
+    puts '<< PREVIEW - Fill in "Highlights" and "Pull Requests and Issues" >>'
+    puts
     puts '**Highlights**'
     puts
     puts "**CC API Version: #{versions[:v2]} and [#{versions[:v3]}](http://v3-apidocs.cloudfoundry.org/version/#{versions[:v3]}/)**"
@@ -275,7 +276,6 @@ module ReleaseNotes
     migrations = get_new_migration_files(ccng_path, old_sha, new_sha)
     puts
     puts '### Cloud Controller Database Migrations'
-    puts
     return puts 'None' if migrations.empty?
 
     base_url = "https://github.com/cloudfoundry/cloud_controller_ng/blob/#{new_sha}/db/migrations"

--- a/ci/git/release_notes.rb
+++ b/ci/git/release_notes.rb
@@ -245,6 +245,7 @@ module ReleaseNotes
     }
   end
 
+  # for local testing setup, see generate_release_notes.sh
   def self.run
     args = ARGV
     raise 'release_notes.rb <previous version> <version> <ccng path>' if args.length != 3

--- a/ci/git/release_notes.rb
+++ b/ci/git/release_notes.rb
@@ -149,58 +149,107 @@ module ReleaseNotes
     puts item_str
   end
 
-  def self.print_release_notes(items)
+  def self.read_cc_versions(ccng_path)
+    config_path = File.join(ccng_path, 'config')
+
+    {
+      v2: File.read(File.join(config_path, 'version_v2')).strip,
+      v3: File.read(File.join(config_path, 'version')).strip,
+      broker: File.read(File.join(config_path, 'osbapi_version')).strip
+    }
+  end
+
+  def self.print_highlights(ccng_path)
+    versions = read_cc_versions(ccng_path)
+
+    puts '**Highlights**'
+    puts
+    puts "**CC API Version: #{versions[:v2]} and [#{versions[:v3]}](http://v3-apidocs.cloudfoundry.org/version/#{versions[:v3]}/)**"
+    puts
+    puts "**Service Broker API Version: [#{versions[:broker]}](https://github.com/openservicebrokerapi/servicebroker/blob/v#{versions[:broker]}/spec.md)**"
+  end
+
+  def self.print_release_overview(capi_sha:, ccng_sha:)
+    puts
+    puts(capi_sha ? "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})" : '### CAPI Release')
+    puts
+    puts(ccng_sha ? "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{ccng_sha})" : '### Cloud Controller')
+  end
+
+  def self.print_subproject_items(items, subproject, github_users)
+    # Print changes
+    changes = items.select { |item| item[:subproject] == subproject && !item[:dependency_update] }
+    changes.each { |item| print_item(item, github_users) }
+
+    # Print dependency updates
+    dependency_updates = items.select { |item| item[:subproject] == subproject && item[:dependency_update] }
+    return if dependency_updates.empty?
+
+    puts '#### Dependency Updates'
+    bumps = {
+      docs_dev: Set.new,
+      docs_deps: Set.new,
+      dev: Set.new,
+      deps: Set.new,
+      other: Set.new
+    }
+    dependency_updates.each do |item|
+      case item[:message]
+      when %r{[Bb]uild\(deps-dev\):.*in /docs/v3}
+        bumps[:docs_dev] << item
+      when %r{[Bb]uild\(deps\):.*in /docs/v3}
+        bumps[:docs_deps] << item
+      when /[Bb]uild\(deps-dev\):/
+        bumps[:dev] << item
+      when /[Bb]uild\(deps\):/
+        bumps[:deps] << item
+      else
+        bumps[:other] << item
+      end
+    end
+
+    %i[other deps dev docs_deps docs_dev].each do |type|
+      bumps[type].each { |item| print_item(item, github_users) }
+    end
+  end
+
+  def self.print_release_notes(items, capi_sha: nil, ccng_sha: nil, include_overview_headings: true, skip_subprojects: nil)
     github_users = {}
+    skipped = Set.new(skip_subprojects)
 
     # Print release notes in the following order: CAPI Release, Cloud Controller, other subprojects
     subprojects = [nil, 'cloud_controller_ng'] + (items.map { |item|
       item[:subproject]
     }.compact.uniq - ['cloud_controller_ng']).sort
     subprojects.each do |subproject|
-      puts "\n"
+      next if skipped.include?(subproject)
+
+      puts
       case subproject
       when nil
-        puts '### CAPI Release'
-      when 'cloud_controller_ng'
-        puts '### Cloud Controller'
-      else
-        puts "### #{subproject}"
-      end
-
-      # Print changes
-      changes = items.select { |item| item[:subproject] == subproject && !item[:dependency_update] }
-      changes.each { |item| print_item(item, github_users) }
-
-      # Print dependency updates
-      dependency_updates = items.select { |item| item[:subproject] == subproject && item[:dependency_update] }
-      next if dependency_updates.empty?
-
-      puts '#### Dependency Updates'
-      bumps = {
-        docs_dev: Set.new,
-        docs_deps: Set.new,
-        dev: Set.new,
-        deps: Set.new,
-        other: Set.new
-      }
-      dependency_updates.each do |item|
-        case item[:message]
-        when %r{[Bb]uild\(deps-dev\):.*in /docs/v3}
-          bumps[:docs_dev] << item
-        when %r{[Bb]uild\(deps\):.*in /docs/v3}
-          bumps[:docs_deps] << item
-        when /[Bb]uild\(deps-dev\):/
-          bumps[:dev] << item
-        when /[Bb]uild\(deps\):/
-          bumps[:deps] << item
+        if include_overview_headings && capi_sha
+          puts "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})"
+        elsif include_overview_headings
+          puts '### CAPI Release'
         else
-          bumps[:other] << item
+          if capi_sha
+            puts "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})"
+          else
+            puts '### CAPI Release'
+          end
         end
+      when 'cloud_controller_ng'
+        if include_overview_headings && ccng_sha
+          puts "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{ccng_sha})"
+        elsif include_overview_headings
+          puts '### Cloud Controller'
+        else
+          puts '##### Cloud Controller'
+        end
+      else
+        puts(include_overview_headings ? "### #{subproject}" : "##### #{subproject}")
       end
-
-      %i[other deps dev docs_deps docs_dev].each do |type|
-        bumps[type].each { |item| print_item(item, github_users) }
-      end
+      print_subproject_items(items, subproject, github_users)
     end
   end
 
@@ -224,12 +273,23 @@ module ReleaseNotes
   def self.print_db_migrations(ccng_path, previous_version, version)
     old_sha, new_sha = get_ccng_shas(previous_version, version)
     migrations = get_new_migration_files(ccng_path, old_sha, new_sha)
-    puts "\n"
+    puts
     puts '### Cloud Controller Database Migrations'
+    puts
     return puts 'None' if migrations.empty?
 
     base_url = "https://github.com/cloudfoundry/cloud_controller_ng/blob/#{new_sha}/db/migrations"
     migrations.each { |f| puts "- [#{f}](#{base_url}/#{f})" }
+  end
+
+  def self.resolve_release_shas(version)
+    capi_sha = `git rev-parse #{version} 2>/dev/null`.strip
+    ccng_sha = `git rev-parse #{version}:src/cloud_controller_ng 2>/dev/null`.strip
+
+    {
+      capi: capi_sha.empty? ? nil : capi_sha,
+      ccng: ccng_sha.empty? ? nil : ccng_sha
+    }
   end
 
   def self.run
@@ -244,8 +304,28 @@ module ReleaseNotes
                 execute_git_log_command(args[0], args[1])
               end
     items = parse_git_log(git_log)
-    print_release_notes(items)
-    print_db_migrations(args[2], args[0], args[1]) unless args.length == 1
+    if args.length == 1
+      print_release_notes(items)
+    else
+      shas = resolve_release_shas(args[1])
+      subprojects = (items.map { |item| item[:subproject] }.compact.uniq - ['cloud_controller_ng']).sort
+      print_highlights(args[2])
+      github_users = {}
+      puts
+      puts(shas[:capi] ? "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{shas[:capi]})" : '### CAPI Release')
+      print_subproject_items(items, nil, github_users)
+      puts
+      puts(shas[:ccng] ? "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{shas[:ccng]})" : '### Cloud Controller')
+      print_subproject_items(items, 'cloud_controller_ng', github_users)
+      subprojects.each do |subproject|
+        puts
+        puts "### #{subproject}"
+        print_subproject_items(items, subproject, github_users)
+      end
+      print_db_migrations(args[2], args[0], args[1])
+      puts
+      puts '#### Pull Requests and Issues'
+    end
   end
 end
 

--- a/ci/git/release_notes.rb
+++ b/ci/git/release_notes.rb
@@ -4,6 +4,7 @@
 require 'cgi/util'
 require 'net/http'
 require 'json'
+require 'set'
 
 module ReleaseNotes
   def self.execute_git_log_command(previous_version, version)
@@ -170,13 +171,6 @@ module ReleaseNotes
     puts "**Service Broker API Version: [#{versions[:broker]}](https://github.com/openservicebrokerapi/servicebroker/blob/v#{versions[:broker]}/spec.md)**"
   end
 
-  def self.print_release_overview(capi_sha:, ccng_sha:)
-    puts
-    puts(capi_sha ? "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})" : '### CAPI Release')
-    puts
-    puts(ccng_sha ? "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{ccng_sha})" : '### Cloud Controller')
-  end
-
   def self.print_subproject_items(items, subproject, github_users)
     # Print changes
     changes = items.select { |item| item[:subproject] == subproject && !item[:dependency_update] }
@@ -214,46 +208,6 @@ module ReleaseNotes
     end
   end
 
-  def self.print_release_notes(items, capi_sha: nil, ccng_sha: nil, include_overview_headings: true, skip_subprojects: nil)
-    github_users = {}
-    skipped = Set.new(skip_subprojects)
-
-    # Print release notes in the following order: CAPI Release, Cloud Controller, other subprojects
-    subprojects = [nil, 'cloud_controller_ng'] + (items.map { |item|
-      item[:subproject]
-    }.compact.uniq - ['cloud_controller_ng']).sort
-    subprojects.each do |subproject|
-      next if skipped.include?(subproject)
-
-      puts
-      case subproject
-      when nil
-        if include_overview_headings && capi_sha
-          puts "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})"
-        elsif include_overview_headings
-          puts '### CAPI Release'
-        else
-          if capi_sha
-            puts "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{capi_sha})"
-          else
-            puts '### CAPI Release'
-          end
-        end
-      when 'cloud_controller_ng'
-        if include_overview_headings && ccng_sha
-          puts "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{ccng_sha})"
-        elsif include_overview_headings
-          puts '### Cloud Controller'
-        else
-          puts '##### Cloud Controller'
-        end
-      else
-        puts(include_overview_headings ? "### #{subproject}" : "##### #{subproject}")
-      end
-      print_subproject_items(items, subproject, github_users)
-    end
-  end
-
   def self.get_ccng_shas(previous_version, version)
     diff = `git diff #{previous_version}...#{version} -- src/cloud_controller_ng`
     old_sha = diff.match(/^-Subproject commit ([0-9a-f]+)/)&.captures&.first
@@ -285,7 +239,6 @@ module ReleaseNotes
   def self.resolve_release_shas(version)
     capi_sha = `git rev-parse #{version} 2>/dev/null`.strip
     ccng_sha = `git rev-parse #{version}:src/cloud_controller_ng 2>/dev/null`.strip
-
     {
       capi: capi_sha.empty? ? nil : capi_sha,
       ccng: ccng_sha.empty? ? nil : ccng_sha
@@ -294,38 +247,36 @@ module ReleaseNotes
 
   def self.run
     args = ARGV
+    raise 'release_notes.rb <previous version> <version> <ccng path>' if args.length != 3
 
-    git_log = if args.length == 1
-                # Test mode, i.e. read given git-log txt file
-                File.read(args[0])
-              else
-                raise 'release_notes.rb <previous version> <version> <ccng path>' if args.length != 3
+    previous_version = args[0]
+    version = args[1]
+    ccng_path = args[2]
 
-                execute_git_log_command(args[0], args[1])
-              end
+    git_log = execute_git_log_command(previous_version, version)
     items = parse_git_log(git_log)
-    if args.length == 1
-      print_release_notes(items)
-    else
-      shas = resolve_release_shas(args[1])
-      subprojects = (items.map { |item| item[:subproject] }.compact.uniq - ['cloud_controller_ng']).sort
-      print_highlights(args[2])
-      github_users = {}
+
+    subprojects = (items.map { |item| item[:subproject] }.compact.uniq - ['cloud_controller_ng']).sort
+    print_highlights(ccng_path)
+    github_users = {}
+
+    shas = resolve_release_shas(version)
+    puts
+    puts(shas[:capi] ? "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{shas[:capi]})" : '### CAPI Release')
+    print_subproject_items(items, nil, github_users)
+    puts
+    puts(shas[:ccng] ? "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{shas[:ccng]})" : '### Cloud Controller')
+
+    print_subproject_items(items, 'cloud_controller_ng', github_users)
+    subprojects.each do |subproject|
       puts
-      puts(shas[:capi] ? "### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/#{shas[:capi]})" : '### CAPI Release')
-      print_subproject_items(items, nil, github_users)
-      puts
-      puts(shas[:ccng] ? "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/#{shas[:ccng]})" : '### Cloud Controller')
-      print_subproject_items(items, 'cloud_controller_ng', github_users)
-      subprojects.each do |subproject|
-        puts
-        puts "### #{subproject}"
-        print_subproject_items(items, subproject, github_users)
-      end
-      print_db_migrations(args[2], args[0], args[1])
-      puts
-      puts '#### Pull Requests and Issues'
+      puts "### #{subproject}"
+      print_subproject_items(items, subproject, github_users)
     end
+
+    print_db_migrations(ccng_path, previous_version, version)
+    puts
+    puts '#### Pull Requests and Issues'
   end
 end
 

--- a/ci/git/release_notes_spec.rb
+++ b/ci/git/release_notes_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe ReleaseNotes do
         allow(ReleaseNotes).to receive(:get_ccng_shas).and_return([old_sha, new_sha])
         allow(ReleaseNotes).to receive(:get_new_migration_files).and_return([migration_filename])
 
-        expected_output = "\n### Cloud Controller Database Migrations\n" \
+        expected_output = "\n### Cloud Controller Database Migrations\n\n" \
           "- [#{migration_filename}](https://github.com/cloudfoundry/cloud_controller_ng/blob/#{new_sha}/db/migrations/#{migration_filename})\n"
         expect { ReleaseNotes.print_db_migrations('/path/to/ccng', '1.231.0', '1.232.0') }
           .to output(expected_output).to_stdout
@@ -176,7 +176,7 @@ RSpec.describe ReleaseNotes do
         allow(ReleaseNotes).to receive(:get_new_migration_files).and_return([])
 
         expect { ReleaseNotes.print_db_migrations('/path/to/ccng', '1.231.0', '1.232.0') }
-          .to output("\n### Cloud Controller Database Migrations\nNone\n").to_stdout
+          .to output("\n### Cloud Controller Database Migrations\n\nNone\n").to_stdout
       end
     end
   end

--- a/ci/git/release_notes_spec.rb
+++ b/ci/git/release_notes_spec.rb
@@ -199,24 +199,6 @@ RSpec.describe ReleaseNotes do
     end
   end
 
-  describe '.print_release_overview' do
-    it 'prints linked headings when SHAs are provided' do
-      expected_output = "\n### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/capi-sha)\n\n" \
-        "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/ccng-sha)\n"
-
-      expect {
-        ReleaseNotes.print_release_overview(capi_sha: 'capi-sha', ccng_sha: 'ccng-sha')
-      }.to output(expected_output).to_stdout
-    end
-
-    it 'prints plain headings when SHAs are not provided' do
-      expected_output = "\n### CAPI Release\n\n### Cloud Controller\n"
-
-      expect {
-        ReleaseNotes.print_release_overview(capi_sha: nil, ccng_sha: nil)
-      }.to output(expected_output).to_stdout
-    end
-  end
 
   describe '.print_subproject_items' do
     it 'prints non-dependency changes for the selected subproject' do

--- a/ci/git/release_notes_spec.rb
+++ b/ci/git/release_notes_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe ReleaseNotes do
         allow(ReleaseNotes).to receive(:get_ccng_shas).and_return([old_sha, new_sha])
         allow(ReleaseNotes).to receive(:get_new_migration_files).and_return([migration_filename])
 
-        expected_output = "\n### Cloud Controller Database Migrations\n\n" \
+        expected_output = "\n### Cloud Controller Database Migrations\n" \
           "- [#{migration_filename}](https://github.com/cloudfoundry/cloud_controller_ng/blob/#{new_sha}/db/migrations/#{migration_filename})\n"
         expect { ReleaseNotes.print_db_migrations('/path/to/ccng', '1.231.0', '1.232.0') }
           .to output(expected_output).to_stdout
@@ -176,8 +176,97 @@ RSpec.describe ReleaseNotes do
         allow(ReleaseNotes).to receive(:get_new_migration_files).and_return([])
 
         expect { ReleaseNotes.print_db_migrations('/path/to/ccng', '1.231.0', '1.232.0') }
-          .to output("\n### Cloud Controller Database Migrations\n\nNone\n").to_stdout
+          .to output("\n### Cloud Controller Database Migrations\nNone\n").to_stdout
       end
+    end
+  end
+
+  describe '.print_highlights' do
+    it 'prints the highlights section with API and broker versions' do
+      allow(ReleaseNotes).to receive(:read_cc_versions).and_return({
+                                                                      v2: '2.286.0',
+                                                                      v3: '3.221.0',
+                                                                      broker: '2.15'
+                                                                    })
+
+      expected_output = "<< PREVIEW - Fill in \"Highlights\" and \"Pull Requests and Issues\" >>\n\n" \
+        "**Highlights**\n\n" \
+        "**CC API Version: 2.286.0 and [3.221.0](http://v3-apidocs.cloudfoundry.org/version/3.221.0/)**\n\n" \
+        "**Service Broker API Version: [2.15](https://github.com/openservicebrokerapi/servicebroker/blob/v2.15/spec.md)**\n"
+
+      expect { ReleaseNotes.print_highlights('/path/to/ccng') }
+        .to output(expected_output).to_stdout
+    end
+  end
+
+  describe '.print_release_overview' do
+    it 'prints linked headings when SHAs are provided' do
+      expected_output = "\n### [CAPI Release](https://github.com/cloudfoundry/capi-release/tree/capi-sha)\n\n" \
+        "### [Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/tree/ccng-sha)\n"
+
+      expect {
+        ReleaseNotes.print_release_overview(capi_sha: 'capi-sha', ccng_sha: 'ccng-sha')
+      }.to output(expected_output).to_stdout
+    end
+
+    it 'prints plain headings when SHAs are not provided' do
+      expected_output = "\n### CAPI Release\n\n### Cloud Controller\n"
+
+      expect {
+        ReleaseNotes.print_release_overview(capi_sha: nil, ccng_sha: nil)
+      }.to output(expected_output).to_stdout
+    end
+  end
+
+  describe '.print_subproject_items' do
+    it 'prints non-dependency changes for the selected subproject' do
+      items = [
+        {
+          subproject: 'cloud_controller_ng',
+          dependency_update: false,
+          message: 'Improve route mapping behavior',
+          pr_link: 'cloudfoundry/cloud_controller_ng#9999',
+          authors: []
+        },
+        {
+          subproject: 'other-subproject',
+          dependency_update: false,
+          message: 'Should not be printed',
+          pr_link: nil,
+          authors: []
+        }
+      ]
+
+      expect {
+        ReleaseNotes.print_subproject_items(items, 'cloud_controller_ng', {})
+      }.to output("- Improve route mapping behavior (cloudfoundry/cloud_controller_ng#9999)\n").to_stdout
+    end
+
+    it 'prints dependency updates grouped under the dependency heading' do
+      items = [
+        {
+          subproject: 'cloud_controller_ng',
+          dependency_update: true,
+          message: 'build(deps): bump rack from 2.2.0 to 2.2.1',
+          pr_link: nil,
+          authors: []
+        },
+        {
+          subproject: 'cloud_controller_ng',
+          dependency_update: true,
+          message: 'build(deps-dev): bump rspec from 3.12.0 to 3.13.0',
+          pr_link: nil,
+          authors: []
+        }
+      ]
+
+      expected_output = "#### Dependency Updates\n" \
+        "- build(deps): bump rack from 2.2.0 to 2.2.1\n" \
+        "- build(deps-dev): bump rspec from 3.12.0 to 3.13.0\n"
+
+      expect {
+        ReleaseNotes.print_subproject_items(items, 'cloud_controller_ng', {})
+      }.to output(expected_output).to_stdout
     end
   end
 end


### PR DESCRIPTION
Align the two release notes scripts used in the capi-ci pipeline. Remove the heredoc from `generate_github_release.sh` and integrate into `release_notes.rb`. Increase unit test coverage in `release_notes_spec.rb`.